### PR TITLE
Added .gitkeep and modified .gitignore to track (empty) Plugins folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ Saved
 CesiumForUnrealSamples.sln
 packages
 Intermediate
-Plugins
+Plugins/*
+!Plugins/.gitkeep 


### PR DESCRIPTION
The readme says:

> From the `cesium-unreal-samples/Plugins` directory, clone Cesium for Unreal using `git clone --recursive git@github.com:CesiumGS/cesium-unreal.git`.

The `Plugins` directory isn't tracked by this repo, so someone who clones it may think they're missing something. I changed the .gitignore settings to track an empty `Plugins` directory.

Could rephrase that line in the readme instead, if that's preferred.